### PR TITLE
Make use of pattern matching for instanceof

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Usage: app [options]
     -o, --output OUTPUT     Output PDF file
 ```
 
+#### Requirements
+
+* JDK 16
+
 #### Building
 
 ```

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,10 @@ plugins {
   id 'application'
 }
 
+tasks.withType(JavaCompile).configureEach {
+  options.incremental = false
+}
+
 repositories {
   jcenter()
 }

--- a/app/src/main/java/au/com/msbit/remove_annotations/Main.java
+++ b/app/src/main/java/au/com/msbit/remove_annotations/Main.java
@@ -35,12 +35,11 @@ class Main {
     }
 
     visit(document.getCatalog().getPdfObject(), (obj) -> {
-      if (!(obj instanceof PdfDictionary)) { return; }
+      if (obj instanceof PdfDictionary dict) {
+        if (!dict.containsKey(PdfName.Annots)) { return; }
 
-      var dict = (PdfDictionary)obj;
-      if (!dict.containsKey(PdfName.Annots)) { return; }
-      
-      dict.remove(PdfName.Annots);
+        dict.remove(PdfName.Annots);
+      }
     });
 
     document.close();
@@ -59,12 +58,12 @@ class Main {
 
       consumer.accept(obj);
 
-      if (obj instanceof PdfDictionary) {
-        for (var v: ((PdfDictionary)obj).values()) { fifo.offerFirst(v); }
+      if (obj instanceof PdfDictionary dict) {
+        for (var v: dict.values()) { fifo.offerFirst(v); }
       }
 
-      if (obj instanceof PdfArray) {
-        for (var c: (PdfArray)obj) { fifo.offerFirst(c); }
+      if (obj instanceof PdfArray array) {
+        for (var c: array) { fifo.offerFirst(c); }
       }
     }
   }


### PR DESCRIPTION
As per http://openjdk.java.net/jeps/394 released as part of
JDK 16, use the pattern matching functionality of instanceof to
avoid explicit casting